### PR TITLE
fix too many open directory error

### DIFF
--- a/data/generate_classifier.go
+++ b/data/generate_classifier.go
@@ -79,7 +79,8 @@ func main() {
 		languages = append(languages, lang)
 
 		samplePath := sourcePath + "/" + lang
-		sampleDir, _ := os.Open(samplePath)
+		sampleDir, err := os.Open(samplePath)
+		checkErr(err)
 		files, err := sampleDir.Readdir(-1)
 		checkErr(err)
 		for _, file := range files {
@@ -90,6 +91,7 @@ func main() {
 			}
 			sampleFiles = append(sampleFiles, &sampleFile{lang, fp, nil})
 		}
+		sampleDir.Close()
 	}
 	log.Println("Found", len(languages), "languages in", len(sampleFiles), "files")
 


### PR DESCRIPTION
Error occured in master branch. following error:

```
$ go run generate_classifier.go
Scanning ./linguist/samples ...
invalid argument
panic: invalid argument


goroutine 1 [running]:
panic(0xeebe0, 0xc4202390b0)
	/usr/local/Cellar/go/1.7.4/libexec/src/runtime/panic.go:500 +0x1a1
log.Panicln(0xc420037940, 0x1, 0x1)
	/usr/local/Cellar/go/1.7.4/libexec/src/log/log.go:334 +0xc9
main.checkErr(0x192300, 0xc42000a1e0)
	/Users/force/.golang/src/github.com/generaltso/linguist/data/generate_classifier.go:172 +0x8a
main.main()
	/Users/force/.golang/src/github.com/generaltso/linguist/data/generate_classifier.go:84 +0x41a
exit status 2
```

leak open files.

Thanks.