### PR TITLE
support overrides from .gitattributes

### DIFF
--- a/cmd/l/main.go
+++ b/cmd/l/main.go
@@ -181,7 +181,7 @@ func main() {
 	}
 
 	if input_mode_fs {
-		initGitIgnore()
+		initLinguistAttributes()
 		processDir(".")
 	}
 


### PR DESCRIPTION
linguist supports a number of different custom overrides strategies for language definitions and vendored paths. This ports that effort over to this Go port of linguist.

See https://github.com/github/linguist#overrides